### PR TITLE
Update Footer.tsx

### DIFF
--- a/src/components/Map/widgets/Footer/Footer.tsx
+++ b/src/components/Map/widgets/Footer/Footer.tsx
@@ -29,7 +29,7 @@ const TimeStampWrapper = styled(Flex)`
 
 function TimeStamp() {
   const { data, isLoading } = useSWR(
-    'https://d1kmd884co9q6x.cloudfront.net/now/timestamp.txt',
+    'https://d1kmd884co9q6x.cloudfront.net/downstream_impact/global_timestamp.txt',
     fetchTimeStamp,
   );
 


### PR DESCRIPTION
Footer was pointing to an outdated time-stamp file that no-longer updates in sync with the downstream predictions. This now points the footer to the correct timestamp.