### PR TITLE
fix: override minScale for stream water company layers

### DIFF
--- a/src/components/Map/commands/AddDischargeSources/AddDischargeSourcesCommand.ts
+++ b/src/components/Map/commands/AddDischargeSources/AddDischargeSourcesCommand.ts
@@ -84,6 +84,7 @@ export class AddDischargeSourcesCommand implements MapCommand {
           portalItem: {
             id: config.apiLayerId,
           },
+          minScale: 0,
           outFields: ['*'],
           renderer: otherWaterAlertStatusRenderer,
           popupTemplate: dischargePopupTemplate,


### PR DESCRIPTION
The new Southern Water ArcGIS layer has a minScale of 964,641, which prevented it from rendering at typical map zoom levels. Set minScale: 0 on all stream-type FeatureLayer instances so the app controls visibility rather than inheriting restrictive service definition defaults.